### PR TITLE
Fix typo in index.html causing error

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
     <script src="js/angular.js"></script>
     <script src="js/angular-messages.js"></script>
     <script src="js/app/app.js"></script>
-    <script src="js/app/controllers/FormController.js></script>"
+    <script src="js/app/controllers/FormController.js"></script>"
 
 </body>
 </html>


### PR DESCRIPTION
Lack of an ending quotation mark keeps the tests from passing

This is due to the FormController.js not loading

Change <script src='js/app/controllers/FormController.js></script>

To now say <script src='js/app/controllers/FormController.js'></script>

This alleviates the error and allows the tests to pass
